### PR TITLE
Generalize product metapackage detection for alternate builds

### DIFF
--- a/lib/internal/Magento/Framework/App/Test/Unit/ProductMetadataTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ProductMetadataTest.php
@@ -77,20 +77,27 @@ class ProductMetadataTest extends TestCase
     public static function testGetVersionGitInstallationDataProvider()
     {
         return [
-            [
+            'community edition package' => [
                 [
-                    0 => [
-                        'name'    => 'magento/product-community-edition',
-                        'version' => '123.456.789'
-                    ],
-                    1 => [
-                        'name'    => 'magento/product-other-edition',
-                        'version' => '987.654.321'
+                    'mage-os/product-community-edition' => [
+                        'name'    => 'mage-os/product-community-edition',
+                        'version' => '1.0.0',
+                        'magento_version' => '123.456.789'
                     ],
                 ],
                 '123.456.789'
             ],
-            [
+            'minimal product package' => [
+                [
+                    'mage-os/product-minimal' => [
+                        'name'    => 'mage-os/product-minimal',
+                        'version' => '2.0.0',
+                        'magento_version' => '234.567.890'
+                    ],
+                ],
+                '234.567.890'
+            ],
+            'empty packages' => [
                 [],
                 'UNKNOWN'
             ]

--- a/lib/internal/Magento/Framework/Composer/ComposerInformation.php
+++ b/lib/internal/Magento/Framework/Composer/ComposerInformation.php
@@ -116,11 +116,12 @@ class ComposerInformation
             foreach ($packages as $package) {
                 if ($package instanceof CompletePackageInterface) {
                     $packageName = $package->getPrettyName();
-                    if ($packageName === 'mage-os/product-community-edition') {
+                    if ($this->isSystemPackage($packageName)) {
                         $phpRequirementLink = $package->getRequires()['php'];
                         if ($phpRequirementLink instanceof Link) {
                             $requiredPhpVersion = $phpRequirementLink->getPrettyConstraint();
                         }
+                        break;
                     }
                 }
             }
@@ -262,7 +263,7 @@ class ComposerInformation
      */
     public function isSystemPackage($packageName = '')
     {
-        if (preg_match('/mage-os\/product-.*?-edition/', $packageName) == 1) {
+        if (preg_match('/^mage-os\/product-.+/', $packageName) == 1) {
             return true;
         }
         return false;

--- a/lib/internal/Magento/Framework/Composer/Test/Unit/ComposerInformationTest.php
+++ b/lib/internal/Magento/Framework/Composer/Test/Unit/ComposerInformationTest.php
@@ -119,4 +119,31 @@ class ComposerInformationTest extends TestCase
             ['namespace/package', false],
         ];
     }
+
+    /**
+     * @param string $packageName
+     * @param boolean $expected
+     * @dataProvider isSystemPackageDataProvider
+     */
+    public function testIsSystemPackage($packageName, $expected)
+    {
+        $this->assertEquals($expected, $this->composerInformation->isSystemPackage($packageName));
+    }
+
+    /**
+     * @return array
+     */
+    public static function isSystemPackageDataProvider()
+    {
+        return [
+            ['mage-os/product-community-edition', true],
+            ['mage-os/product-enterprise-edition', true],
+            ['mage-os/product-minimal', true],
+            ['mage-os/product-custom-build', true],
+            ['magento/product-community-edition', false],
+            ['mage-os/module-something', false],
+            ['namespace/package', false],
+            ['mage-os/product-', false],
+        ];
+    }
 }


### PR DESCRIPTION
The system package detection was previously hardcoded to only recognize
packages matching `mage-os/product-*-edition`. This change generalizes
the regex to match any `mage-os/product-*` package, enabling support for
alternate product metapackages like `mage-os/product-minimal`.

- Update isSystemPackage() regex to match any mage-os/product-* package
- Update getRequiredPhpVersion() to use isSystemPackage() instead of
  hardcoded package name
- Add unit tests for isSystemPackage() with various package patterns
- Update ProductMetadataTest to use proper mage-os package names

https://claude.ai/code/session_01KVLKuTyatjiMtYp2npbqgc