### PR TITLE
Fix PHP 8.4 lazy-ghost layout corruption in view/page result types (#284)

### DIFF
--- a/lib/internal/Magento/Framework/App/View.php
+++ b/lib/internal/Magento/Framework/App/View.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\App;
 
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class View implements ViewInterface
 {
     /**

--- a/lib/internal/Magento/Framework/View/Result/Layout.php
+++ b/lib/internal/Magento/Framework/View/Result/Layout.php
@@ -21,6 +21,7 @@ use Magento\Framework\View;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Layout extends AbstractResult
 {
     /**

--- a/lib/internal/Magento/Framework/View/Result/Page.php
+++ b/lib/internal/Magento/Framework/View/Result/Page.php
@@ -44,6 +44,7 @@ use Magento\Framework\View\EntitySpecificHandlesList;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Page extends Layout
 {
     /**


### PR DESCRIPTION
## Summary
Fixes #284. Under PHP 8.4 lazy-ghost DI, classes whose constructors mutate shared singleton services are unsafe to defer. `App\View`, `View\Result\Page`, and `View\Result\Layout` all attach a builder to (and set the generator pool on) the **shared, non-isolated** `Layout` in their constructors. When lazy-ghosting defers that constructor, the builder is swapped onto an already-built Layout mid-request and `Layout::build()` (which has no built-guard) rebuilds and discards runtime structure — e.g. legacy admin controllers calling `$this->_view->getLayout()` inside `_addContent()` fail with "The element with the 'adminhtml\transaction\edit_0' ID wasn't found."

## Fix
Add the existing `#[\Magento\Framework\ObjectManager\Attribute\NonLazy]` marker (already used on ~75 core classes) to the three concrete result types, forcing eager construction — the pre-PHP-8.4 default.

| File | Why |
|------|-----|
| `App/View.php` | ctor calls `pageFactory->create(true)`, mutating the shared Layout (the case in the issue) |
| `View/Result/Page.php` | the actual mutator; lazy-eligible via ~98 `resultPageFactory->create()` controller callsites that bypass `App\View` |
| `View/Result/Layout.php` | same mutation for the `ResultFactory::TYPE_LAYOUT` path; needs its own marker since attribute reflection doesn't inherit the child's |

## Notes
- The marker is a silent no-op on stock Magento (attribute target classes aren't autoloaded), so this stays cross-compatible.
- `Layout\Builder` / `Page\Builder` also call `setBuilder()` but are only created via factory with call-time args, which are never lazy-ghosted — marking them would be a no-op, so they're intentionally left alone.
- Did not add a built-guard to `Layout::build()` (the issue's alternate suggestion); it's a hot-path behavioral change with its own BC risk and the opt-outs fully resolve the failure.

## BC impact
None. Forces eager construction of these types (historical behavior); no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)